### PR TITLE
fixed typo

### DIFF
--- a/packages/docs/src/routes/docs/(qwik)/getting-started/index.mdx
+++ b/packages/docs/src/routes/docs/(qwik)/getting-started/index.mdx
@@ -367,7 +367,7 @@ export default component$(() => {
 
 In Qwik, a [task](/docs/components/tasks/#usetask) is work that needs to happen when a state changes. (This is similar to an "effect" in other frameworks.) In this example, we use the task to invoke code on the server.
 
-1. Import `useTask$` from `qwik` and `$server` from `qwik-city`.
+1. Import `useTask$` from `qwik` and `server$` from `qwik-city`.
    ```tsx /useTask\$/ /\$server/
    import { component$, useSignal, useTask$ } from "@builder.io/qwik";
    import {


### PR DESCRIPTION
Fixed typo in documentation

# What is it?
- Docs / tests / types / typos


# Description
Fixed a typo in docs that tells to import `$server` from `quick-city` instead of `server$`

# Checklist

- [x] My code follows the [developer guidelines of this project](https://github.com/QwikDev/qwik/blob/main/CONTRIBUTING.md)
- [x] I performed a self-review of my own code
